### PR TITLE
Add background colour to user hover popup

### DIFF
--- a/dark-facebook.css
+++ b/dark-facebook.css
@@ -3,7 +3,7 @@
  * https://github.com/dtinth/dark-facebook
  */
 /* this is compiled source code, for original source code see src/main.styl */
-/* generated: Sat Oct 20 2012 16:43:21 GMT+0700 (ICT) */body{background-color:#252423 !important;}
+/* generated: Wed Dec 19 2012 20:40:51 GMT+0100 (CET) */body{background-color:#252423 !important;}
 body,body *{border-color:#31302f !important}
 body,body *{color:#e9e8e7 !important}
 body *{background-color:transparent !important}
@@ -57,6 +57,8 @@ body:not(.timelineLayout) .uiSideHeader a,body:not(.timelineLayout) .uiSideHeade
 .belowleft .uiTooltipX i.arrow,.belowright .uiTooltipX i.arrow,.belowcenter .uiTooltipX i.arrow{border-bottom-color:#090807 !important}
 .left .uiTooltipX i.arrow{border-left-color:#090807 !important}
 .right .uiTooltipX i.arrow{border-right-color:#090807 !important}
+.-cx-PRIVATE-uiContextualDialog__content{background-color:#353433 !important;}
+.uiBoxGray{background-color:#252423 !important;}
 .uiOverlay{background-color:transparent !important;}
 .uiOverlay .uiOverlayContent{background-color:#353433 !important;}
 .uiOverlay .uiOverlayContent,.uiOverlay .uiOverlayContent *{border-color:#454443 !important}

--- a/src/main.styl
+++ b/src/main.styl
@@ -310,6 +310,12 @@ tooltipx-border(pos)
 	tooltipx-border: left
 .right
 	tooltipx-border: right
+
+// user hover popup
+.-cx-PRIVATE-uiContextualDialog__content
+	colorize: $main-background
+.uiBoxGray
+	colorize: $page-background
 	
 
 


### PR DESCRIPTION
Right now when you hover over someone's username, you can see through the popup. This pull request adds a background colour.
